### PR TITLE
support --tag in enable command

### DIFF
--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -5,21 +5,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var enableCmd = &cobra.Command{
-	Use:   "enable <service>",
-	Short: "Enable a service",
-	Run: func(cmd *cobra.Command, args []string) {
-		switch args[0] {
-		case "postgres":
-			services.EnablePostgres(false)
-		case "timescale":
-			services.EnablePostgres(true)
-		case "redis":
-			services.EnableRedis()
-		case "mysql":
-			services.EnableMysql()
-		case "chrome":
-			services.EnableChrome()
-		}
-	},
+func enableCommand() *cobra.Command {
+
+	var enableCmd = &cobra.Command{
+		Use:   "enable <service> [--tag=IMAGE_TAG]",
+		Short: "Enable a service",
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "postgres":
+				services.EnablePostgres(cmd, args, false)
+			case "timescale":
+				services.EnablePostgres(cmd, args, true)
+			case "redis":
+				services.EnableRedis()
+			case "mysql":
+				services.EnableMysql()
+			case "chrome":
+				services.EnableChrome()
+			}
+		},
+	}
+
+	enableCmd.Flags().String("tag", "", "Specify an image tag to pull")
+
+	return enableCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ func Execute() {
 	rootCmd.Flags().BoolVarP(&displayVersion, "version", "v", false, "Displays version number")
 
 	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(enableCmd)
+	rootCmd.AddCommand(enableCommand())
 	rootCmd.AddCommand(disableCmd)
 	rootCmd.AddCommand(replCmd)
 

--- a/services/postgres.go
+++ b/services/postgres.go
@@ -5,19 +5,40 @@ import (
 	"log"
 
 	"github.com/egoist/doko/utils"
+	"github.com/spf13/cobra"
 )
 
 // EnablePostgres starts a docker container for postgres
-func EnablePostgres(timescale bool) {
-	image := "postgres:12-alpine"
-	if timescale {
-		image = "timescale/timescaledb:latest-pg12"
+func EnablePostgres(cmd *cobra.Command, args []string, timescale bool) {
+	var imageName string
+	var imageTag string
+	var imageFullName string
+
+	imageTag, getTagErr := cmd.Flags().GetString("tag")
+
+	if getTagErr != nil {
+		log.Fatal(getTagErr)
 	}
+
+	if timescale {
+		imageName = "timescale/timescaledb"
+		if imageTag == "" {
+			imageTag = "latest-pg12"
+		}
+	} else {
+		imageName = "postgres"
+		if imageTag == "" {
+			imageTag = "12-alpine"
+		}
+	}
+
+	imageFullName = fmt.Sprintf("%s:%s", imageName, imageTag)
+
 	err := utils.DockerRun(utils.RunOptions{
 		Name:   "postgres",
 		Port:   "5432",
 		Env:    []string{"POSTGRES_PASSWORD=pass"},
-		Image:  image,
+		Image:  imageFullName,
 		Volume: "postgres_data:/var/lib/postgresql/data",
 	})
 	if err != nil {


### PR DESCRIPTION
This PR supports the `enable` command to receive a `--tag` flag to customize the image tag.

For example the default postgres version of `doku enable postgres` is `12`, but we can use `--tag=13-alpine` to pull pgsql 13:

```
doku enable postgres --tag 13-alpine
```
